### PR TITLE
Run containers directly from flash

### DIFF
--- a/about.rst
+++ b/about.rst
@@ -95,4 +95,5 @@ sharing values between instances.
 See also
 --------
 
-[rBPF paper](https://hal.inria.fr/hal-03019639)
+- `rBPF paper <https://hal.inria.fr/hal-03019639>`__
+- `Linux BPF Documentation <https://www.kernel.org/doc/html/latest/bpf/index.html>`__

--- a/bpf/bpf.c
+++ b/bpf/bpf.c
@@ -65,12 +65,12 @@ void bpf_setup(bpf_t *bpf)
     bpf->stack_region.next = &bpf->data_region;
 
     bpf->data_region.start = rbpf_data(bpf);
-    bpf->data_region.len = rbpf_header(bpf)->data_len;
+    bpf->data_region.len = rbpf_header(bpf).data_len;
     bpf->data_region.flag = (BPF_MEM_REGION_READ | BPF_MEM_REGION_WRITE);
     bpf->data_region.next = &bpf->rodata_region;
 
     bpf->rodata_region.start = rbpf_rodata(bpf);
-    bpf->rodata_region.len = rbpf_header(bpf)->rodata_len;
+    bpf->rodata_region.len = rbpf_header(bpf).rodata_len;
     bpf->rodata_region.flag = BPF_MEM_REGION_READ;
     bpf->rodata_region.next = &bpf->arg_region;
 

--- a/bpf/bpf.c
+++ b/bpf/bpf.c
@@ -60,6 +60,10 @@ int bpf_execute_ctx(bpf_t *bpf, void *ctx, size_t ctx_len, int64_t *result)
 
 int bpf_setup(bpf_t *bpf)
 {
+    if(bpf == NULL) {
+        return -1;
+    }
+
     bpf->stack_region.start = bpf->stack_region.phys_start = bpf->stack;
     bpf->stack_region.len = bpf->stack_size;
     bpf->stack_region.flag = (BPF_MEM_REGION_READ | BPF_MEM_REGION_WRITE);

--- a/bpf/bpf.c
+++ b/bpf/bpf.c
@@ -67,16 +67,17 @@ int bpf_setup(bpf_t *bpf)
 
     rbpf_header_t hdr = rbpf_header(bpf);
 
-    size_t len = ALIGNUP4(hdr.data_len);
+    size_t len = ALIGNUP4(hdr.data_len + hdr.bss_len);
     if(len == 0) {
         bpf->data_region.start = bpf->data_region.phys_start = NULL;
     } else {
         bpf->data_region.start = rbpf_data(bpf);
-        void* ptr = malloc(len);
+        uint8_t* ptr = malloc(len);
         if(ptr == NULL) {
             return -1;
         }
-        memcpy(ptr, bpf->data_region.start, len);
+        memcpy(ptr, bpf->data_region.start, ALIGNUP4(hdr.data_len));
+        memset(ptr + hdr.data_len, 0, hdr.bss_len);
         bpf->data_region.phys_start = ptr;
     }
     bpf->data_region.len = len;

--- a/bpf/call.c
+++ b/bpf/call.c
@@ -10,8 +10,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdbool.h>
-#include <stdio.h>
-#include <string.h>
+#include <FakePgmSpace.h>
 
 #include "bpf.h"
 #include "bpf/instruction.h"
@@ -34,7 +33,15 @@
 uint32_t bpf_vm_printf(bpf_t *bpf, uint32_t fmt, uint32_t a2, uint32_t a3, uint32_t a4, uint32_t a5)
 {
     (void)bpf;
-    return printf((char*)(uintptr_t)fmt, a2, a3, a4, a5);
+    const char* fmt_ptr = (const char*)fmt;
+    if(isFlashPtr(fmt_ptr)) {
+        size_t len = ALIGNUP4(strlen_P(fmt_ptr) + 1);
+        char buf[len];
+        memcpy(buf, fmt_ptr, len);
+        return m_printf(buf, a2, a3, a4, a5);
+    }
+
+    return m_printf(fmt_ptr, a2, a3, a4, a5);
 }
 
 uint32_t bpf_vm_store_local(bpf_t *bpf, uint32_t key, uint32_t value, uint32_t a3, uint32_t a4, uint32_t a5)

--- a/bpf/include/bpf.h
+++ b/bpf/include/bpf.h
@@ -50,6 +50,7 @@ typedef struct __attribute__((packed)) {
     uint32_t version;    /**< Version of the application */
     uint32_t flags;
     uint32_t data_len;   /**< Length of the data section */
+    uint32_t bss_len;    /**< Length of the BSS section */
     uint32_t rodata_len; /**< Length of the rodata section */
     uint32_t text_len;   /**< Length of the text section */
     uint32_t functions;  /**< Number of functions available */

--- a/bpf/include/bpf.h
+++ b/bpf/include/bpf.h
@@ -97,6 +97,7 @@ typedef struct bpf_mem_region bpf_mem_region_t;
 struct bpf_mem_region {
     bpf_mem_region_t *next;
     const uint8_t *start;
+    const uint8_t *phys_start;
     size_t len;
     uint8_t flag;
 };
@@ -129,7 +130,8 @@ struct bpf_hook {
 };
 
 void bpf_init(void);
-void bpf_setup(bpf_t *bpf);
+int bpf_setup(bpf_t *bpf);
+void bpf_destroy(bpf_t *bpf);
 
 int bpf_verify_preflight(bpf_t *bpf);
 

--- a/bpf/include/bpf.h
+++ b/bpf/include/bpf.h
@@ -108,14 +108,16 @@ struct bpf_mem_region {
 #define BPF_CONFIG_NO_RETURN       0x0100 /**< Script doesn't need to have a return */
 
 typedef struct bpf_s {
-    bpf_mem_region_t stack_region;
-    bpf_mem_region_t rodata_region;
-    bpf_mem_region_t data_region;
-    bpf_mem_region_t arg_region;
+    // Initialised by application
     const uint8_t *application; /**< Application bytecode */
     size_t application_len;     /**< Application length */
     uint8_t *stack;             /**< VM stack, must be a multiple of 8 bytes and aligned */
     size_t stack_size;          /**< VM stack size in bytes */
+    // Initialised by bpf_setup()
+    bpf_mem_region_t stack_region;
+    bpf_mem_region_t rodata_region;
+    bpf_mem_region_t data_region;
+    bpf_mem_region_t arg_region;
     btree_t btree;              /**< Local btree */
     uint16_t flags;
     uint32_t branches_remaining; /**< Number of allowed branch instructions remaining */

--- a/bpf/include/bpf/bpfapi/helpers.h
+++ b/bpf/include/bpf/bpfapi/helpers.h
@@ -21,40 +21,44 @@ extern "C" {
 
 typedef signed ssize_t;
 
+#define DEFINE_SYSCALL(syscall_id, ResultType, name, ...) \
+    static ResultType (*name)(__VA_ARGS__) = (ResultType(*)(__VA_ARGS__))syscall_id;
+
+
 /**
  * Opaque dummy type saul registration
  */
 typedef void bpf_saul_reg_t;
 
-static void *(*bpf_printf)(const char *fmt, ...) = (void *) BPF_FUNC_BPF_PRINTF;
+DEFINE_SYSCALL(BPF_FUNC_BPF_PRINTF, void, bpf_printf, const char *, ...)
 
-static int (*bpf_store_global)(uint32_t key, uint32_t value) = (void *) BPF_FUNC_BPF_STORE_GLOBAL;
-static int (*bpf_store_local)(uint32_t key, uint32_t value) = (void *) BPF_FUNC_BPF_STORE_LOCAL;
-static int (*bpf_fetch_global)(uint32_t key, uint32_t *value) = (void *) BPF_FUNC_BPF_FETCH_GLOBAL;
-static int (*bpf_fetch_local)(uint32_t key, uint32_t *value) = (void *) BPF_FUNC_BPF_FETCH_LOCAL;
-static uint32_t (*bpf_now_ms)(void) = (void *) BPF_FUNC_BPF_NOW_MS;
+DEFINE_SYSCALL(BPF_FUNC_BPF_STORE_GLOBAL, int, bpf_store_global, uint32_t key, uint32_t value)
+DEFINE_SYSCALL(BPF_FUNC_BPF_STORE_LOCAL, int, bpf_store_local, uint32_t key, uint32_t value)
+DEFINE_SYSCALL(BPF_FUNC_BPF_FETCH_GLOBAL, int, bpf_fetch_global, uint32_t key, uint32_t *value)
+DEFINE_SYSCALL(BPF_FUNC_BPF_FETCH_LOCAL, int, bpf_fetch_local, uint32_t key, uint32_t *value)
+DEFINE_SYSCALL(BPF_FUNC_BPF_NOW_MS, uint32_t, bpf_now_ms, void)
 
 /* STDLIB */
-static void *(*bpf_memcpy)(void *dest, const void *src, size_t n) = (void *) BPF_FUNC_BPF_MEMCPY;
+DEFINE_SYSCALL(BPF_FUNC_BPF_MEMCPY, void, bpf_memcpy, void *dest, const void *src, size_t n)
 
 /* SAUL calls */
-static bpf_saul_reg_t *(*bpf_saul_reg_find_nth)(int pos) = (void *) BPF_FUNC_BPF_SAUL_REG_FIND_NTH;
-static bpf_saul_reg_t *(*bpf_saul_reg_find_type)(uint8_t type) = (void *) BPF_FUNC_BPF_SAUL_REG_FIND_TYPE;
-static int (*bpf_saul_reg_read)(bpf_saul_reg_t *dev, phydat_t *data) = (void *) BPF_FUNC_BPF_SAUL_REG_READ;
+DEFINE_SYSCALL(BPF_FUNC_BPF_SAUL_REG_FIND_NTH, bpf_saul_reg_t *, bpf_saul_reg_find_nth, int pos)
+DEFINE_SYSCALL(BPF_FUNC_BPF_SAUL_REG_FIND_TYPE, bpf_saul_reg_t *, bpf_saul_reg_find_type, uint8_t type)
+DEFINE_SYSCALL(BPF_FUNC_BPF_SAUL_REG_READ, int , bpf_saul_reg_read, bpf_saul_reg_t *dev, phydat_t *data)
 
 /* CoAP calls */
-static void (*bpf_gcoap_resp_init)(bpf_coap_ctx_t *ctx, unsigned resp_code) = (void *) BPF_FUNC_BPF_GCOAP_RESP_INIT;
-static ssize_t (*bpf_coap_opt_finish)(bpf_coap_ctx_t *ctx, unsigned opt) = (void *) BPF_FUNC_BPF_COAP_OPT_FINISH;
-static void (*bpf_coap_add_format)(bpf_coap_ctx_t *ctx, uint32_t format) = (void *) BPF_FUNC_BPF_COAP_ADD_FORMAT;
-static uint8_t *(*bpf_coap_get_pdu)(bpf_coap_ctx_t *ctx) = (void *) BPF_FUNC_BPF_COAP_GET_PDU;
+DEFINE_SYSCALL(BPF_FUNC_BPF_GCOAP_RESP_INIT, void , bpf_gcoap_resp_init, bpf_coap_ctx_t *ctx, unsigned resp_code)
+DEFINE_SYSCALL(BPF_FUNC_BPF_COAP_OPT_FINISH, ssize_t , bpf_coap_opt_finish, bpf_coap_ctx_t *ctx, unsigned opt)
+DEFINE_SYSCALL(BPF_FUNC_BPF_COAP_ADD_FORMAT, void , bpf_coap_add_format, bpf_coap_ctx_t *ctx, uint32_t format)
+DEFINE_SYSCALL(BPF_FUNC_BPF_COAP_GET_PDU, uint8_t *, bpf_coap_get_pdu, bpf_coap_ctx_t *ctx)
 
 /* FMT calls */
-static size_t (*bpf_fmt_s16_dfp)(char *out, int16_t val, int fp_digits) = (void *) BPF_FUNC_BPF_FMT_S16_DFP;
-static size_t (*bpf_fmt_u32_dec)(char *out, uint32_t val) = (void *) BPF_FUNC_BPF_FMT_U32_DEC;
+DEFINE_SYSCALL(BPF_FUNC_BPF_FMT_S16_DFP, size_t , bpf_fmt_s16_dfp, char *out, int16_t val, int fp_digits)
+DEFINE_SYSCALL(BPF_FUNC_BPF_FMT_U32_DEC, size_t , bpf_fmt_u32_dec, char *out, uint32_t val)
 
 /* ZTIMER calls */
-static uint32_t (*bpf_ztimer_now)(void) = (void *) BPF_FUNC_BPF_ZTIMER_NOW;
-static void (*bpf_ztimer_periodic_wakeup)(uint32_t *last_wakeup, uint32_t period) = (void *) BPF_FUNC_BPF_ZTIMER_PERIODIC_WAKEUP;
+DEFINE_SYSCALL(BPF_FUNC_BPF_ZTIMER_NOW, uint32_t , bpf_ztimer_now, void)
+DEFINE_SYSCALL(BPF_FUNC_BPF_ZTIMER_PERIODIC_WAKEUP, void , bpf_ztimer_periodic_wakeup, uint32_t *last_wakeup, uint32_t period)
 
 #ifdef __cplusplus
 

--- a/bpf/include/bpf/instruction.h
+++ b/bpf/include/bpf/instruction.h
@@ -94,6 +94,16 @@ typedef struct __attribute__((packed)) {
     int32_t immediate;
 } bpf_instruction_t;
 
+/*
+ * Make use of  strict volatile bitfield access to ensure flash accesses are aligned.
+ */
+typedef union {
+    uint64_t value;
+    bpf_instruction_t inst;
+} bpf_instruction_ptr_t;
+
+#define GET_INSTRUCTION(p) (((const volatile bpf_instruction_ptr_t*)(p))->inst)
+
 #ifdef __cplusplus
 }
 #endif

--- a/component.mk
+++ b/component.mk
@@ -1,4 +1,9 @@
+# The folder where the container application source code is stored.
+RBPF_CONTAINER_PATH ?= container
+RBPF_CONTAINER_PATH := $(call AbsoluteSourcePath,$(PROJECT_DIR),$(RBPF_CONTAINER_PATH))
+
 COMPONENT_INCDIRS := \
+	$(RBPF_CONTAINER_PATH)/include \
 	src/include \
 	bpf/include
 
@@ -21,10 +26,6 @@ COMPONENT_DOXYGEN_INPUT := src/include
 
 RBPF_COMPONENT_PATH := $(COMPONENT_PATH)
 export RBPF_GENRBF := $(PYTHON) $(COMPONENT_PATH)/tools/gen_rbf.py $(if $(V),--verbose)
-
-# The folder where the container application source code is stored.
-RBPF_CONTAINER_PATH ?= container
-RBPF_CONTAINER_PATH := $(call AbsoluteSourcePath,$(PROJECT_DIR),$(RBPF_CONTAINER_PATH))
 
 ##@rBPF containers
 

--- a/component.mk
+++ b/component.mk
@@ -23,7 +23,8 @@ RBPF_COMPONENT_PATH := $(COMPONENT_PATH)
 export RBPF_GENRBF := $(PYTHON) $(COMPONENT_PATH)/tools/gen_rbf.py $(if $(V),--verbose)
 
 # The folder where the container application source code is stored.
-RBPF_CONTAINER_PATH ?= $(PROJECT_DIR)/container
+RBPF_CONTAINER_PATH ?= container
+RBPF_CONTAINER_PATH := $(call AbsoluteSourcePath,$(PROJECT_DIR),$(RBPF_CONTAINER_PATH))
 
 ##@rBPF containers
 

--- a/rbpf.inc.mk
+++ b/rbpf.inc.mk
@@ -28,6 +28,7 @@ all: blobs
 INC_FLAGS = \
 	-nostdinc \
 	-isystem `$(CLANG) -print-file-name=include` \
+	-Iinclude \
 	-I$(RBPF_COMPONENT_DIR)/bpf/include \
 	-I$(RBPF_COMPONENT_DIR)/src/include/bpf
 

--- a/rbpf.inc.mk
+++ b/rbpf.inc.mk
@@ -6,6 +6,7 @@ endif
 
 RBPF_OBJDIR := $(RBPF_OUTDIR)/obj
 RBPF_INCDIR := $(RBPF_OUTDIR)/include
+RBPF_COMPONENT_DIR := $(call dirx,$(firstword $(MAKEFILE_LIST)))
 
 # Obtain blob file path
 # $1 -> source file(s)
@@ -27,7 +28,8 @@ all: blobs
 INC_FLAGS = \
 	-nostdinc \
 	-isystem `$(CLANG) -print-file-name=include` \
-	-I$(dir $(firstword $(MAKEFILE_LIST)))bpf/include
+	-I$(RBPF_COMPONENT_DIR)/bpf/include \
+	-I$(RBPF_COMPONENT_DIR)/src/include/bpf
 
 # Generate build targets
 # $1 -> Source file

--- a/samples/Basic_VM/app/application.cpp
+++ b/samples/Basic_VM/app/application.cpp
@@ -66,19 +66,21 @@ void test_store()
 	rBPF::VirtualMachine vm(rBPF::Container::store);
 	vm.globals[1] = 1234;
 	vm.locals[2] = 5678;
-	auto res = vm.execute(nullptr, 0);
-	if(vm.getLastError() == 0) {
-		Serial.print(_F("output ("));
-		Serial.print(vm.globals[1]);
-		Serial.print(", ");
-		Serial.print(vm.locals[2]);
-		uint32_t value1 = res >> 32;
-		uint32_t value2 = res;
-		Serial.print(_F("), result ("));
-		Serial.print(value1);
-		Serial.print(", ");
-		Serial.print(value2);
-		Serial.println(")");
+	for(unsigned i = 0; i < 3; ++i) {
+		auto res = vm.execute(nullptr, 0);
+		if(vm.getLastError() == 0) {
+			Serial.print(_F("output ("));
+			Serial.print(vm.globals[1]);
+			Serial.print(", ");
+			Serial.print(vm.locals[2]);
+			uint32_t value1 = res >> 32;
+			uint32_t value2 = res;
+			Serial.print(_F("), result ("));
+			Serial.print(value1);
+			Serial.print(", ");
+			Serial.print(value2);
+			Serial.println(")");
+		}
 	}
 }
 

--- a/samples/Basic_VM/app/application.cpp
+++ b/samples/Basic_VM/app/application.cpp
@@ -63,7 +63,7 @@ void test_multiply()
 void test_store()
 {
 	Serial.println(F("Calling 'store()' in VM"));
-	rBPF::VirtualMachine vm(rBPF::Container::store);
+	rBPF::VirtualMachine vm(rBPF::Container::store, 32);
 	vm.globals[1] = 1234;
 	vm.locals[2] = 5678;
 	for(unsigned i = 0; i < 3; ++i) {

--- a/samples/Basic_VM/component.mk
+++ b/samples/Basic_VM/component.mk
@@ -1,5 +1,2 @@
 COMPONENT_DEPENDS := rbpf
 DISABLE_NETWORK := 1
-
-# We require access to container header files which define shared structures
-COMPONENT_INCDIRS := container/include

--- a/samples/Basic_VM/container/store.c
+++ b/samples/Basic_VM/container/store.c
@@ -2,6 +2,9 @@
 
 int64_t store()
 {
+	static const char str1[] = ">> Now in VM running store() <<\r\n";
+	bpf_printf(str1);
+
 	uint32_t value1 = 0;
 	bpf_fetch_global(1, &value1);
 	uint32_t value2 = 0;
@@ -10,5 +13,10 @@ int64_t store()
 	bpf_store_global(1, value1 + 1000000);
 	bpf_store_local(2, value2 + 2000000);
 
-	return ((uint64_t)value1 << 32) | value2;
+	uint64_t res = ((uint64_t)value1 << 32) | value2;
+
+	static const char str2[] = ">> Now leaving store() <<\r\n";
+	bpf_printf(str2);
+
+	return res;
 }

--- a/samples/Basic_VM/container/store.c
+++ b/samples/Basic_VM/container/store.c
@@ -5,10 +5,8 @@ static uint32_t lastValue2 = 3; // Allocate in DATA
 
 int64_t store()
 {
-	static const char str1[] = ">> Now in VM running store() <<\r\n";
-	bpf_printf(str1);
-	static const char str1a[] = "lastValue (%u, %u)\r\n";
-	bpf_printf(str1a, lastValue1, lastValue2);
+	bpf_printf(">> Now in VM running store() <<\r\n");
+	bpf_printf("lastValue (%u, %u)\r\n", lastValue1, lastValue2);
 
 	uint32_t value1 = 0;
 	bpf_fetch_global(1, &value1);
@@ -23,8 +21,7 @@ int64_t store()
 
 	uint64_t res = ((uint64_t)value1 << 32) | value2;
 
-	static const char str2[] = ">> Now leaving store() <<\r\n";
-	bpf_printf(str2);
+	bpf_printf(">> Now leaving store() <<\r\n");
 
 	return res;
 }

--- a/samples/Basic_VM/container/store.c
+++ b/samples/Basic_VM/container/store.c
@@ -1,14 +1,22 @@
 #include <bpf/bpfapi/helpers.h>
 
+static uint32_t lastValue1 = 1;
+static uint32_t lastValue2 = 1;
+
 int64_t store()
 {
 	static const char str1[] = ">> Now in VM running store() <<\r\n";
 	bpf_printf(str1);
+	static const char str1a[] = "lastValue (%u, %u)\r\n";
+	bpf_printf(str1a, lastValue1, lastValue2);
 
 	uint32_t value1 = 0;
 	bpf_fetch_global(1, &value1);
 	uint32_t value2 = 0;
 	bpf_fetch_local(2, &value2);
+
+	lastValue1 = value1;
+	lastValue2 = value2;
 
 	bpf_store_global(1, value1 + 1000000);
 	bpf_store_local(2, value2 + 2000000);

--- a/samples/Basic_VM/container/store.c
+++ b/samples/Basic_VM/container/store.c
@@ -1,7 +1,7 @@
 #include <bpf/bpfapi/helpers.h>
 
-static uint32_t lastValue1 = 1;
-static uint32_t lastValue2 = 1;
+static uint32_t lastValue1;		// Allocated in BSS
+static uint32_t lastValue2 = 3; // Allocate in DATA
 
 int64_t store()
 {

--- a/src/VirtualMachine.cpp
+++ b/src/VirtualMachine.cpp
@@ -47,11 +47,14 @@ VirtualMachine::VirtualMachine() : locals(*this)
 
 VirtualMachine::~VirtualMachine()
 {
+	unload();
 }
 
 bool VirtualMachine::load(const Container& container)
 {
 	check_init();
+
+	unload();
 
 	this->container = &container;
 
@@ -64,6 +67,15 @@ bool VirtualMachine::load(const Container& container)
 
 	bpf_setup(inst.get());
 	return true;
+}
+
+void VirtualMachine::unload()
+{
+	if(inst) {
+		bpf_destroy(inst.get());
+		inst.reset();
+	}
+	lastError = 0;
 }
 
 int64_t VirtualMachine::execute(void* ctx, size_t ctxLength)

--- a/src/include/bpf/rbpf/Store.h
+++ b/src/include/bpf/rbpf/Store.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "../../rbpf/common/Store.h"
+#include <bpf/bpfapi/helpers.h>
+
+namespace rBPF
+{
+class LocalStore : public Store
+{
+public:
+	bool update(Key key, Value value) override
+	{
+		return bpf_store_local(key, value) == 0;
+	}
+
+	bool fetch(Key key, Value& value) override
+	{
+		return bpf_fetch_local(key, &value) == 0;
+	}
+};
+
+class GlobalStore : public Store
+{
+public:
+	bool update(Key key, Value value) override
+	{
+		return bpf_store_global(key, value) == 0;
+	}
+
+	bool fetch(Key key, Value& value) override
+	{
+		return bpf_fetch_global(key, &value) == 0;
+	}
+};
+
+} // namespace rBPF

--- a/src/include/rbpf/Store.h
+++ b/src/include/rbpf/Store.h
@@ -1,62 +1,10 @@
 #pragma once
 
-#include <cstdint>
+#include "common/Store.h"
 
 namespace rBPF
 {
 class VirtualMachine;
-
-class Store
-{
-public:
-	using Key = uint32_t;
-	using Value = uint32_t;
-
-	class Entry
-	{
-	public:
-		explicit operator bool() const
-		{
-			return valid;
-		}
-
-		Entry& operator=(Value value)
-		{
-			valid = store.update(key, value);
-			return *this;
-		}
-
-		operator Value() const
-		{
-			return store.get(key);
-		}
-
-	private:
-		friend Store;
-
-		Entry(Store& store, Key key) : store(store), key(key)
-		{
-		}
-
-		Store& store;
-		Key key;
-		bool valid;
-	};
-
-	virtual bool update(Key key, Value value) = 0;
-	virtual bool fetch(Key key, Value& value) = 0;
-
-	Value get(Key key, Value defaultValue = 0)
-	{
-		Value res;
-		return fetch(key, res) ? res : defaultValue;
-	}
-
-	Entry operator[](Key key)
-	{
-		return Entry(*this, key);
-	}
-};
 
 class LocalStore : public Store
 {

--- a/src/include/rbpf/VirtualMachine.h
+++ b/src/include/rbpf/VirtualMachine.h
@@ -35,7 +35,16 @@ public:
 
 	~VirtualMachine();
 
+	/**
+	 * @brief Load container and initialise it
+	 * @retval bool true on success
+	 */
 	bool load(const Container& container);
+
+	/**
+	 * @brief Unload container and free any allocated resources
+	 */
+	void unload();
 
 	/**
      * @name Run the container

--- a/src/include/rbpf/VirtualMachine.h
+++ b/src/include/rbpf/VirtualMachine.h
@@ -18,6 +18,7 @@ class VirtualMachine
 {
 public:
 	using Container = FSTR::Array<uint8_t>;
+	static constexpr size_t defaultStackSize{512};
 
 	/**
 	 * @brief Create an uninitialised VM
@@ -28,9 +29,9 @@ public:
      * @name Create a VM and load a container
      * @param container Container code blob
      */
-	VirtualMachine(const Container& container) : VirtualMachine()
+	VirtualMachine(const Container& container, size_t stackSize = defaultStackSize) : VirtualMachine()
 	{
-		load(container);
+		load(container, stackSize);
 	}
 
 	~VirtualMachine();
@@ -39,7 +40,7 @@ public:
 	 * @brief Load container and initialise it
 	 * @retval bool true on success
 	 */
-	bool load(const Container& container);
+	bool load(const Container& container, size_t stackSize = defaultStackSize);
 
 	/**
 	 * @brief Unload container and free any allocated resources
@@ -82,7 +83,8 @@ private:
 
 	const Container* container{nullptr};
 	std::unique_ptr<struct bpf_s> inst;
-	uint8_t stack[512]{};
+	std::unique_ptr<uint8_t> stack;
+	size_t stackSize{0};
 	int lastError{0};
 };
 

--- a/src/include/rbpf/VirtualMachine.h
+++ b/src/include/rbpf/VirtualMachine.h
@@ -5,6 +5,8 @@
 #include "Store.h"
 #include <memory>
 
+struct bpf_s;
+
 namespace rBPF
 {
 /**
@@ -18,13 +20,22 @@ public:
 	using Container = FSTR::Array<uint8_t>;
 
 	/**
-     * @name Create a container
+	 * @brief Create an uninitialised VM
+	 */
+	VirtualMachine();
+
+	/**
+     * @name Create a VM and load a container
      * @param container Container code blob
      */
-	VirtualMachine(const Container& container) : locals(*this)
+	VirtualMachine(const Container& container) : VirtualMachine()
 	{
-		init(container);
+		load(container);
 	}
+
+	~VirtualMachine();
+
+	bool load(const Container& container);
 
 	/**
      * @name Run the container
@@ -60,10 +71,8 @@ public:
 private:
 	friend class LocalStore;
 
-	bool init(const Container& container);
-
-	std::unique_ptr<uint8_t> appBinary;
-	std::unique_ptr<uint8_t> inst;
+	const Container* container{nullptr};
+	std::unique_ptr<struct bpf_s> inst;
 	uint8_t stack[512]{};
 	int lastError{0};
 };

--- a/src/include/rbpf/common/Store.h
+++ b/src/include/rbpf/common/Store.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace rBPF
+{
+class Store
+{
+public:
+	using Key = uint32_t;
+	using Value = uint32_t;
+
+	class Entry
+	{
+	public:
+		explicit operator bool() const
+		{
+			return valid;
+		}
+
+		Entry& operator=(Value value)
+		{
+			valid = store.update(key, value);
+			return *this;
+		}
+
+		operator Value() const
+		{
+			return store.get(key);
+		}
+
+	private:
+		friend Store;
+
+		Entry(Store& store, Key key) : store(store), key(key)
+		{
+		}
+
+		Store& store;
+		Key key;
+		bool valid;
+	};
+
+	virtual bool update(Key key, Value value) = 0;
+	virtual bool fetch(Key key, Value& value) = 0;
+
+	Value get(Key key, Value defaultValue = 0)
+	{
+		Value res;
+		return fetch(key, res) ? res : defaultValue;
+	}
+
+	Entry operator[](Key key)
+	{
+		return Entry(*this, key);
+	}
+};
+
+} // namespace rBPF

--- a/tools/rbpf/instructions.py
+++ b/tools/rbpf/instructions.py
@@ -325,7 +325,7 @@ class LDDWInstruction(LoadInstruction):
     def __init__(self, registers, offset, immediate_l, immediate_h, address=0, compressed_address=0):
         self.immediate_l = immediate_l
         self.immediate_h = immediate_h
-        print(f"imm {hex(self.immediate_l)}, {hex(self.immediate_h)}")
+        logging.info(f"imm {hex(self.immediate_l)}, {hex(self.immediate_h)}")
         immediate = (self.immediate_h << 32) + self.immediate_l
         super().__init__(registers, offset, immediate, address, compressed_address)
 

--- a/tools/rbpf/rbf.py
+++ b/tools/rbpf/rbf.py
@@ -7,13 +7,14 @@ import itertools
 
 MAGIC = int.from_bytes(b'rBPF', "little")
 
-HEADER_STRUCT = struct.Struct('<IIIIIII')
-HEADER = namedtuple('Header', 'magic version flags data_len rodata_len text_len functions_len')
+HEADER_STRUCT = struct.Struct('<8I')
+HEADER = namedtuple('Header', 'magic version flags data_len bss_len rodata_len text_len functions_len')
 
 SYMBOL_STRUCT = struct.Struct('<HHH')
 SYMBOL = namedtuple('Symbol', 'name_offset flags location_offset')
 
 TEXT = '.text'
+BSS = '.bss'
 DATA = '.data'
 RODATA = '.rodata'
 SYMBOLS = '.symtab'
@@ -30,10 +31,11 @@ class Symbol(object):
 class RBF(object):
 
 
-    def __init__(self, data, rodata, text, symbols, header=None):
+    def __init__(self, data, bss_len, rodata, text, symbols, header=None):
         self.data = data
         self.rodata = rodata
         self.text = text
+        self.bss_len = bss_len
         self.header = header
         if header:
             self.flags = self.header.flags
@@ -92,9 +94,10 @@ class RBF(object):
         print(f"Magic:\t\t{hex(self.header.magic)}\n"
               f"Version:\t{self.header.version}\n"
               f"flags:\t{hex(self.flags)}\n"
-              f"Data length:\t{self.header.data_len} B\n"
-              f"RoData length:\t{self.header.rodata_len} B\n"
-              f"Text length:\t{self.header.text_len} B\n"
+              f"DATA length:\t{self.header.data_len} B\n"
+              f"BSS length:\t{self.header.bss_len} B\n"
+              f"RODATA length:\t{self.header.rodata_len} B\n"
+              f"TEXT length:\t{self.header.text_len} B\n"
               f"No. functions:\t{self.header.functions_len}\n"
               )
         print("functions:")
@@ -121,7 +124,7 @@ class RBF(object):
 
     def format(self):
         if not self.header:
-            self.header = HEADER(MAGIC, 0, 0, len(self.data), len(self.rodata),
+            self.header = HEADER(MAGIC, 0, 0, len(self.data), self.bss_len, len(self.rodata),
                                  len(self.text), len(self.symbols))
 
         data = bytearray(HEADER_STRUCT.pack(*self.header))
@@ -168,19 +171,19 @@ class RBF(object):
                 SYMBOL._make(SYMBOL_STRUCT.unpack_from(syms, 0))
             )
             syms = syms[SYMBOL_STRUCT.size:]
-        return RBF(data, rodata, text, syms_array, header)
+        return RBF(data=data, bss_len=header.bss_len, rodata=rodata, text=text, symbols=syms_array, header=header)
 
 
     @staticmethod
     def _get_section_lddw_opcode(section):
         if section == RODATA:
             return instructions.LDDWR_OPCODE
-        if section == DATA:
+        if section == DATA or section == BSS:
             return instructions.LDDWD_OPCODE
         raise RuntimeError(f'Invalid section found {section}')
 
     @staticmethod
-    def _patch_text(text, elffile, relocation):
+    def _patch_text(text, elffile, relocation, data_len, bss_len):
         entry = relocation.entry
         location = entry.r_offset
         symbols = elffile.get_section_by_name(SYMBOLS)
@@ -188,7 +191,14 @@ class RBF(object):
         if symbol.entry.st_info.type == 'STT_SECTION':
             # refers to an offset in a section
             section_name = elffile.get_section(symbol.entry.st_shndx).name
-            offset = 0
+            if section_name == RODATA:
+                offset = 0 #data_len + bss_len
+            elif section_name == DATA:
+                offset = 0
+            elif section_name == BSS:
+                offset = data_len
+            else:
+                raise RuntimeError(f"Bad section {section_name}")
         elif symbol.entry.st_info.type == 'STT_OBJECT':
             section_name = elffile.get_section(symbol.entry.st_shndx).name
             offset = symbol.entry.st_value
@@ -217,6 +227,7 @@ class RBF(object):
         relocations = elffile.get_section_by_name(RELOCATIONS)
         elf_text = elffile.get_section_by_name(TEXT)
         elf_data = elffile.get_section_by_name(DATA)
+        elf_bss = elffile.get_section_by_name(BSS)
         elf_rodata = elffile.get_section_by_name(RODATA)
         if not elf_rodata:
             rodata = bytearray()
@@ -230,6 +241,7 @@ class RBF(object):
             data = bytearray()
         else:
             data = bytearray(elf_data.data())
+        bss_len = elf_bss.data_size if elf_bss else 0
 
         symbols = elffile.get_section_by_name(SYMBOLS)
 
@@ -266,6 +278,6 @@ class RBF(object):
                     section = elffile.get_section(symbol.entry.st_shndx)
                     logging.info(f"relocation at instruction {hex(entry['r_offset'])} for symbol {name} in {section.name} at {symbol.entry.st_value}")
 
-                RBF._patch_text(text, elffile, relocation)
+                RBF._patch_text(text, elffile, relocation, len(data), bss_len)
 
-        return RBF(data=data, rodata=rodata, text=text, symbols=symbol_structs)
+        return RBF(data=data, bss_len=bss_len, rodata=rodata, text=text, symbols=symbol_structs)


### PR DESCRIPTION
- Instead of copying container into RAM, run it directly from flash.
- Get `bpf_printf` working.
- Add check for invalid sections to `gen_rbf` tool
- Add Store class for container use

Note: This changes the rBPF header as it's necessary to add a BSS length field.

TODO:

* [x] BSS/Data sections must be allocated to RAM on loading
* [x] Update RBPF tool to handle BSS section - static/global data must otherwise be initialised to non-zero values
* [x] Find out how to merge sections. Direct string usage such as `bpf_printf("hello");` won't work because it gets put in a section called `.rodata.str1.1`.
